### PR TITLE
Text clipping

### DIFF
--- a/lib/core/src/lib.rs
+++ b/lib/core/src/lib.rs
@@ -137,10 +137,9 @@ mod example_03 {
                 let area = Area {
                     left   : x,
                     right  : x + 0.5,
-                    top    : y + 0.1,
+                    top    : y,
                     bottom : y - 0.2
                 };
-                let line_position = nalgebra::Vector2::new(x,y);
                 let text_compnent = crate::text::TextComponentBuilder {
                     text : "To be, or not to be, that is the question:\n\
                         Whether 'tis nobler in the mind to suffer\n\
@@ -149,7 +148,7 @@ mod example_03 {
                         And by opposing end them."
                         .to_string(),
                     font     : &mut fonts[font],
-                    position : line_position,
+                    scroll_position: nalgebra::Vector2::new(0.0, 0.05),
                     size     : SIZES[size],
                     color    : Color {r: 1.0, g: 1.0, b: 1.0, a: 1.0},
                     area
@@ -180,6 +179,16 @@ pub struct Area<T> {
     pub right  : T,
     pub top    : T,
     pub bottom : T,
+}
+
+impl<T:std::ops::Sub+Clone> Area<T> {
+    pub fn width(&self) -> T::Output {
+        self.right.clone() - self.left.clone()
+    }
+
+    pub fn height(&self) -> T::Output {
+        self.top.clone() - self.bottom.clone()
+    }
 }
 
 // ===============

--- a/lib/core/src/lib.rs
+++ b/lib/core/src/lib.rs
@@ -99,7 +99,7 @@ mod example_03 {
     use crate::utils;
     use crate::display::world::{World,Workspace,Add};
     use crate::text::font::FontRenderInfo;
-    use crate::Color;
+    use crate::{Area,Color};
 
     use crate::dirty::traits::SharedSetter1;
     use basegl_core_embedded_fonts::EmbeddedFonts;
@@ -134,6 +134,12 @@ mod example_03 {
 
                 let x = -0.95 + 0.6 * (size as f64);
                 let y = 0.90 - 0.45 * (font as f64);
+                let area = Area {
+                    left   : x,
+                    right  : x + 0.5,
+                    top    : y + 0.1,
+                    bottom : y - 0.2
+                };
                 let line_position = nalgebra::Vector2::new(x,y);
                 let text_compnent = crate::text::TextComponentBuilder {
                     text : "To be, or not to be, that is the question:\n\
@@ -146,6 +152,7 @@ mod example_03 {
                     position : line_position,
                     size     : SIZES[size],
                     color    : Color {r: 1.0, g: 1.0, b: 1.0, a: 1.0},
+                    area
                 }.build(workspace);
                 workspace.text_components.push(text_compnent);
             }
@@ -164,9 +171,16 @@ pub struct Color<T> {
     pub r : T,
     pub g : T,
     pub b : T,
-    pub a : T
+    pub a : T,
 }
 
+#[derive(Debug)]
+pub struct Area<T> {
+    pub left   : T,
+    pub right  : T,
+    pub top    : T,
+    pub bottom : T,
+}
 
 // ===============
 // === Printer ===

--- a/lib/core/src/text.rs
+++ b/lib/core/src/text.rs
@@ -11,7 +11,7 @@ use crate::text::msdf::MsdfTexture;
 
 use font::FontRenderInfo;
 use basegl_backend_webgl::{Context,compile_shader,link_program,Program,Shader};
-use nalgebra::{Vector2,Similarity2,Transform2};
+use nalgebra::{Vector2,Similarity2,Point2,Projective2};
 use web_sys::{WebGlRenderingContext,WebGlBuffer,WebGlTexture};
 
 
@@ -30,7 +30,7 @@ pub struct TextComponent {
     gl_msdf_texture : WebGlTexture,
     lines           : Vec<Line>,
     buffers         : TextComponentBuffers,
-    to_window       : Transform2<f64>
+    to_window       : Projective2<f64>
 }
 
 #[derive(Debug)]
@@ -68,11 +68,11 @@ impl TextComponent {
         gl_context.bind_buffer(target,Some(buffer));
         gl_context.vertex_attrib_pointer_with_i32
         ( location
-            , item_size
-            , item_type
-            , normalized
-            , stride
-            , offset
+        , item_size
+        , item_type
+        , normalized
+        , stride
+        , offset
         );
     }
 
@@ -95,12 +95,12 @@ impl TextComponent {
 
 /// Text component builder
 pub struct TextComponentBuilder<'a, Str:AsRef<str>> {
-    pub text     : Str,
-    pub font     : &'a mut FontRenderInfo,
-    pub position : Vector2<f64>,
-    pub size     : f64,
-    pub color    : Color<f32>,
-    pub area     : Area<f64>
+    pub text            : Str,
+    pub font            : &'a mut FontRenderInfo,
+    pub scroll_position : Vector2<f64>,
+    pub size            : f64,
+    pub color           : Color<f32>,
+    pub area            : Area<f64>
 }
 
 impl<'a,Str:AsRef<str>> TextComponentBuilder<'a,Str> {
@@ -108,17 +108,14 @@ impl<'a,Str:AsRef<str>> TextComponentBuilder<'a,Str> {
     /// Build a new text component rendering on given workspace
     pub fn build(mut self, workspace : &Workspace) -> TextComponent {
         self.load_all_chars();
-        let displayed_lines   = 100; // TODO[AO] replace with actual component size
-        let displayed_columns = 100;
         let gl_context        = workspace.context.clone();
         let gl_program        = self.create_program(&gl_context);
         let gl_msdf_texture   = self.create_msdf_texture(&gl_context);
         let lines             = self.split_lines();
-        let mut buffers       = TextComponentBuffers::new(&gl_context,displayed_lines,displayed_columns);
         let to_window         = self.to_window_transform();
-
+        let mut buffers       = self.create_buffers(&gl_context, &to_window);
         self.setup_uniforms(&gl_context,&gl_program,&to_window);
-        buffers.refresh_all(&gl_context,&lines,self.font,&to_window);
+        buffers.refresh_all(&gl_context,&lines,self.font);
         TextComponent {
             gl_context,
             gl_program,
@@ -168,9 +165,11 @@ impl<'a,Str:AsRef<str>> TextComponentBuilder<'a,Str> {
         compile_shader(gl_context,shader_type,body).unwrap()
     }
 
-    fn to_window_transform(&self) -> Transform2<f64> {
-        const ROTATION : f64 = 0.0;
-        let similarity       = Similarity2::new(self.position,ROTATION,self.size);
+    fn to_window_transform(&self) -> Projective2<f64> {
+        const ROTATION : f64  = 0.0;
+        let base_position     = Vector2::new(self.area.left,self.area.top);
+        let scrolled_position = base_position - self.scroll_position;
+        let similarity        = Similarity2::new(scrolled_position,ROTATION,self.size);
         nalgebra::convert(similarity)
     }
 
@@ -209,7 +208,23 @@ impl<'a,Str:AsRef<str>> TextComponentBuilder<'a,Str> {
         msdf_texture
     }
 
-    fn setup_uniforms(&self, gl_context:&Context, gl_program:&Program, to_window:&Transform2<f64>) {
+    fn create_buffers(&mut self, gl_context:&Context, to_window:&Projective2<f64>)
+    -> TextComponentBuffers {
+        let from_window       = to_window.inverse();
+        let component_lb      = Point2::new(self.area.left, self.area.bottom);
+        let component_rt      = Point2::new(self.area.right, self.area.top);
+        let displayed_text_lb = from_window * component_lb;
+        let displayed_text_rt = from_window * component_rt;
+        let displayed_text    = Area {
+            left              : displayed_text_lb.x,
+            right             : displayed_text_rt.x,
+            top               : displayed_text_rt.y,
+            bottom            : displayed_text_lb.y,
+        };
+        TextComponentBuffers::new(gl_context,displayed_text,self.font)
+    }
+
+    fn setup_uniforms(&self, gl_context:&Context, gl_program:&Program, to_window:&Projective2<f64>) {
         let to_window_converted = Self::convert_to_window(to_window);
         let to_window_ref       = to_window_converted.as_ref();
         let area                = &self.area;
@@ -236,7 +251,7 @@ impl<'a,Str:AsRef<str>> TextComponentBuilder<'a,Str> {
         gl_context.uniform2f(msdf_size_loc.as_ref(),msdf_width,msdf_height);
     }
 
-    fn convert_to_window(to_window:&Transform2<f64>) -> SmallVec<[f32;9]> {
+    fn convert_to_window(to_window:&Projective2<f64>) -> SmallVec<[f32;9]> {
         let matrix            = to_window.matrix();
         let view : &[[f64;3]] = matrix.as_ref();
         let flatten_view      = view.iter().flatten();

--- a/lib/core/src/text/buffer.rs
+++ b/lib/core/src/text/buffer.rs
@@ -1,18 +1,19 @@
+pub mod fragment;
 pub mod glyph_square;
 pub mod line;
 
 use crate::prelude::*;
 
-use crate::text::buffer::glyph_square::
-{GlyphVertexPositionBuilder, GlyphTextureCoordsBuilder, GlyphAttributeBuilder, BASE_LAYOUT_SIZE};
-use crate::text::buffer::line::LineAttributeBuilder;
+use crate::text::buffer::glyph_square::BASE_LAYOUT_SIZE;
+use crate::text::buffer::fragment::{BufferFragment,FragmentsDataBuilder};
 use crate::text::Line;
 use crate::text::font::FontRenderInfo;
 
 use basegl_backend_webgl::Context;
 use js_sys::Float32Array;
-use nalgebra::Transform2;
 use web_sys::WebGlBuffer;
+use std::ops::RangeInclusive;
+use crate::Area;
 
 
 // =============================
@@ -26,119 +27,89 @@ use web_sys::WebGlBuffer;
 #[derive(Debug)]
 pub struct TextComponentBuffers {
     pub vertex_position     : WebGlBuffer,
-    pub texture_coords: WebGlBuffer,
+    pub texture_coords      : WebGlBuffer,
     fragments               : Vec<BufferFragment>,
+    pub clip                : Area<f64>,
     pub displayed_lines     : usize,
-    pub displayed_columns   : usize,
-}
-
-/// A buffer fragment which may be assigned to some line.
-#[derive(Debug)]
-struct BufferFragment {
-    assigned_line              : Option<usize>
-    // TODO [AO] maybe some new fields appear in future. if not, remove this and use Option<usize>
-    // directly
+    pub max_displayed_chars : usize,
 }
 
 impl TextComponentBuffers {
     /// Create and initialize buffers.
-    pub fn new(gl_context:&Context, displayed_lines:usize, displayed_columns:usize)
+    pub fn new(gl_context:&Context, clip:Area<f64>, font:&mut FontRenderInfo)
     -> TextComponentBuffers {
+        let displayed_lines     = clip.height().ceil() as usize;
+        let space_width         = font.get_glyph_info(' ').advance;
+        let max_displayed_chars = (clip.width().ceil() / space_width) as usize;
         TextComponentBuffers {
             vertex_position   : gl_context.create_buffer().unwrap(),
             texture_coords    : gl_context.create_buffer().unwrap(),
             fragments         : Self::build_fragments(displayed_lines),
+            clip,
             displayed_lines,
-            displayed_columns,
+            max_displayed_chars
         }
     }
 
     fn build_fragments(displayed_lines:usize) -> Vec<BufferFragment> {
         let indexes   = 0..displayed_lines;
-        let fragments = indexes.map(|_| BufferFragment { assigned_line : None });
+        let fragments = indexes.map(|_| BufferFragment::unassigned());
         fragments.collect()
     }
 
     /// Refresh the whole buffers making them display the given lines.
     pub fn refresh_all<'a>
-    ( &mut self
-    , gl_context:&Context
-    , lines:&[Line]
-    , font:&'a mut FontRenderInfo
-    , to_window:&Transform2<f64>
-    ) {
-        self.assign_fragments(lines.len());
+    (&mut self, gl_context:&Context, lines:&[Line], font:&'a mut FontRenderInfo) {
+        let top_line_clipped     = Self::line_at_y_position(self.clip.top,lines.len());
+        let bottom_line_clipped  = Self::line_at_y_position(self.clip.bottom,lines.len());
+        let first_line_index     = top_line_clipped.unwrap_or(0);
+        let last_line_index      = bottom_line_clipped.unwrap_or(lines.len()-1);
+        let mut builder          = self.create_fragments_data_builder(font);
 
-        let content_from_index = |index : Option<usize>| index.map_or("", |i| lines[i].content.as_str());
-
-        let assigned_lines     = self.fragments.iter().map(|fragment| fragment.assigned_line);
-        let content            = assigned_lines.clone().map(content_from_index);
-        let line_indexes       = assigned_lines.map(|index| index.unwrap_or(0));
-        let content_with_index = content.clone().zip(line_indexes);
-
-        self.refresh_vertex_position_buffer(gl_context,content_with_index,font,to_window);
-        self.refresh_texture_coords_buffer (gl_context,content           ,font);
-    }
-
-    fn refresh_vertex_position_buffer<'a, Iter>
-    ( &self
-    , gl_context:&Context
-    , content_with_index:Iter
-    , font:&mut FontRenderInfo
-    , to_window:&Transform2<f64>
-    ) where Iter : ExactSizeIterator<Item=(&'a str,usize)> {
-        let one_glyph_data_size = GlyphVertexPositionBuilder::OUTPUT_SIZE;
-        let mut data            = Vec::new();
-        let lines_count         = content_with_index.len();
-        let line_length         = self.displayed_columns;
-        let data_size           = one_glyph_data_size * line_length * lines_count;
-
-        data.reserve(data_size);
-        for (content, index) in content_with_index {
-            let glyph_buider = GlyphVertexPositionBuilder::new(font,*to_window,index);
-            let builder      = LineAttributeBuilder::new(content,glyph_buider,line_length);
-            data.extend(builder.flatten().map(|f| f as f32));
+        self.assign_fragments(first_line_index..=last_line_index);
+        for fragment in &mut self.fragments {
+            let index   = fragment.assigned_line.unwrap_or(0);
+            let content = fragment.assigned_line.map_or("", |i| lines[i].content.as_str());
+            builder.build_for_line(index,content);
         }
-
-        self.set_buffer_data(gl_context,&self.vertex_position,data.as_ref());
+        let vertex_position_data = builder.vertex_position_data;
+        let texture_coords_data  = builder.texture_coords_data;
+        self.set_buffer_data(gl_context,&self.vertex_position,vertex_position_data.as_ref());
+        self.set_buffer_data(gl_context,&self.texture_coords ,texture_coords_data .as_ref());
     }
 
-    fn refresh_texture_coords_buffer<'a, Iter>
-    (&self, gl_context:&Context, content:Iter, font:&mut FontRenderInfo)
-    where Iter : ExactSizeIterator<Item=&'a str>
-    {
-        let one_glyph_data_size = GlyphTextureCoordsBuilder::OUTPUT_SIZE;
-        let mut data            = Vec::new();
-        let lines_count         = content.len();
-        let line_length         = self.displayed_columns;
-        let data_size           = one_glyph_data_size * line_length * lines_count;
-
-        data.reserve(data_size);
-        for line in content {
-            let glyph_buider = GlyphTextureCoordsBuilder::new(font);
-            let builder      = LineAttributeBuilder::new(line,glyph_buider,line_length);
-            data.extend(builder.flatten().map(|f| f as f32));
-        }
-
-        self.set_buffer_data(gl_context,&self.texture_coords,data.as_ref());
+    fn line_at_y_position(y:f64, lines_count:usize) -> Option<usize> {
+        let index    = -y.floor();
+        let is_valid = index >= 0.0 && index < lines_count as f64;
+        is_valid.and_option_from(|| Some(index as usize))
     }
 
-    fn assign_fragments(&mut self, lines_count:usize) {
+    fn assign_fragments(&mut self, displayed_lines:RangeInclusive<usize>) {
         for (i, fragment) in self.fragments.iter_mut().enumerate() {
-            fragment.assigned_line = (i < lines_count).and_option(Some(i))
+            let assigned_index     = displayed_lines.start() + i;
+            let is_line_to_assign  = assigned_index <= *displayed_lines.end();
+            fragment.assigned_line = is_line_to_assign.and_option(Some(i))
+        }
+    }
+
+    fn create_fragments_data_builder(&self, font:&mut FontRenderInfo) -> FragmentsDataBuilder {
+        FragmentsDataBuilder {
+            vertex_position_data : Vec::new(),
+            texture_coords_data  : Vec::new(),
+            font,
+            line_clip            : self.clip.left..self.clip.right,
+            max_displayed_chars  : self.max_displayed_chars
         }
     }
 
     fn set_buffer_data(&self, gl_context:&Context, buffer:&WebGlBuffer, vertices:&[f32]) {
-        let target     = Context::ARRAY_BUFFER;
-
+        let target = Context::ARRAY_BUFFER;
         gl_context.bind_buffer(target,Some(&buffer));
         Self::set_bound_buffer_data(gl_context,target,vertices);
     }
 
     fn set_bound_buffer_data(gl_context:&Context, target:u32, data:&[f32]) {
         let usage      = Context::STATIC_DRAW;
-
         unsafe { // Note [unsafe buffer_data]
             let float_32_array = Float32Array::view(&data);
             gl_context.buffer_data_with_array_buffer_view(target,&float_32_array,usage);
@@ -154,6 +125,6 @@ impl TextComponentBuffers {
      */
 
     pub fn vertices_count(&self) -> usize {
-        BASE_LAYOUT_SIZE * self.displayed_lines * self.displayed_columns
+        BASE_LAYOUT_SIZE * self.displayed_lines * self.max_displayed_chars
     }
 }

--- a/lib/core/src/text/buffer.rs
+++ b/lib/core/src/text/buffer.rs
@@ -92,7 +92,8 @@ impl TextComponentBuffers {
         }
     }
 
-    fn create_fragments_data_builder(&self, font:&mut FontRenderInfo) -> FragmentsDataBuilder {
+    fn create_fragments_data_builder<'a>(&self, font:&'a mut FontRenderInfo)
+    -> FragmentsDataBuilder<'a> {
         FragmentsDataBuilder {
             vertex_position_data : Vec::new(),
             texture_coords_data  : Vec::new(),

--- a/lib/core/src/text/buffer/fragment.rs
+++ b/lib/core/src/text/buffer/fragment.rs
@@ -1,0 +1,247 @@
+use crate::prelude::*;
+
+use crate::text::buffer::glyph_square::{Pen,GlyphVertexPositionBuilder,GlyphTextureCoordsBuilder};
+use crate::text::buffer::line::LineAttributeBuilder;
+use crate::text::font::FontRenderInfo;
+
+use nalgebra::geometry::Point2;
+use std::ops::Range;
+
+// ======================
+// === BufferFragment ===
+// ======================
+
+/// Buffer Fragment
+///
+/// The buffers of TextComponent are split to equally-sized fragments, and each fragment may be
+/// assigned to some line. Thanks to that we can easily refresh only minimal subset of lines and
+/// quickly replace line with another during scrolling.
+#[derive(Debug)]
+pub struct BufferFragment {
+    pub assigned_line     : Option<usize>,
+    pub rendered_fragment : Option<RenderedFragment>
+}
+
+/// Information what is currently rendered on screen for some specific _buffer fragment_.
+#[derive(Debug)]
+pub struct RenderedFragment {
+    pub first_char : RenderedChar,
+    pub last_char  : RenderedChar,
+}
+
+/// The rendered char position in line and on screen.
+#[derive(Debug)]
+pub struct RenderedChar {
+    pub byte_offset : usize,
+    pub pen         : Pen
+}
+
+impl BufferFragment {
+    /// Creates new buffer fragment which is not assigned to any line.
+    pub fn unassigned() -> BufferFragment {
+        BufferFragment {
+            assigned_line     : None,
+            rendered_fragment : None
+        }
+    }
+}
+
+// ===========================
+// === FragmentDataBuilder ===
+// ===========================
+
+/// Builder of buffer data of some consecutive buffer fragments
+///
+/// The result is stored in `vertex_position_data` and `texture_coords_data` fields.
+pub struct FragmentsDataBuilder<'a> {
+    pub vertex_position_data : Vec<f32>,
+    pub texture_coords_data  : Vec<f32>,
+    pub font                 : &'a mut FontRenderInfo,
+    pub line_clip            : Range<f64>,
+    pub max_displayed_chars  : usize,
+}
+
+impl<'a> FragmentsDataBuilder<'a> {
+
+    /// Append buffers' data for fragment assigned to `line`
+    pub fn build_for_line(&mut self, line_index:usize, line:&str) -> Option<RenderedFragment> {
+        let line_y         = -(line_index as f64) - 1.0;
+        let mut pen        = Pen::new(Point2::new(0.0, line_y));
+        let first_char     = self.first_rendered_char(&mut pen,&line);
+        let first_char_ref = first_char.as_ref();
+        let rendered_text  = first_char_ref.map_or(line, |rch| &line[rch.byte_offset..]);
+        let last_char      = first_char_ref.map(|fc| self.last_rendered_char(&fc,rendered_text));
+        self.build_vertex_positions(&pen,rendered_text);
+        self.build_texture_coords(&rendered_text);
+        match (first_char,last_char.flatten()) {
+            (Some(fch),Some(lch)) => Some(RenderedFragment{first_char:fch, last_char:lch}),
+            _                     => None
+        }
+    }
+
+    /// Get information about first char which data will be actually stored in buffer.
+    pub fn first_rendered_char(&mut self, pen:&mut Pen, line:&str) -> Option<RenderedChar> {
+        let line_length         = line.chars().count();
+        let always_render_index = line_length.saturating_sub(self.max_displayed_chars);
+        let line_clip           = &self.line_clip;
+        let font                = &mut self.font;
+        let pen_per_char        = line.chars().map(|c| { pen.next_char(c,font).clone() });
+        let chars_with_index    = line.char_indices().enumerate();
+        let chars_with_pen      = chars_with_index.zip(pen_per_char);
+        let mut chars           = chars_with_pen.map(|((ind,(offset,ch)),pen)| (ind,offset,ch,pen));
+
+        chars.find_map(|(index,offset,_,pen)| {
+            let byte_offset = offset;
+            let visible     = pen.is_in_x_range(line_clip);
+            let rendered    = visible || index >= always_render_index;
+            rendered.and_option_from(|| Some(RenderedChar{byte_offset,pen}))
+        })
+    }
+
+    /// Get information about last char which data will be actually stored in buffer.
+    pub fn last_rendered_char(&mut self, first_char:&RenderedChar, rendered_text:&str)
+    -> Option<RenderedChar> {
+        let mut pen               = first_char.pen.clone();
+        let rendered_chars_iter   = rendered_text.char_indices().take(self.max_displayed_chars);
+        let (last_char_offset, _) = rendered_chars_iter.clone().last()?;
+        let byte_offset = first_char.byte_offset + last_char_offset;
+        for (_, ch) in rendered_chars_iter.skip(1) {
+            pen.next_char(ch, &mut self.font);
+        }
+        Some(RenderedChar { byte_offset, pen })
+    }
+
+    /// Extend vertex position data with a new line's.
+    pub fn build_vertex_positions(&mut self, pen:&Pen, text:&str) {
+        let rendering_pen = Pen::new(pen.position);
+        let glyph_builder = GlyphVertexPositionBuilder::new(self.font,rendering_pen);
+        let builder       = LineAttributeBuilder::new(text,glyph_builder,self.max_displayed_chars);
+        self.vertex_position_data.extend(builder.flatten().map(|f| f as f32));
+    }
+
+    /// Extend texture coordinates data with a new line's.
+    pub fn build_texture_coords(&mut self, text:&str) {
+        let glyph_builder = GlyphTextureCoordsBuilder::new(self.font);
+        let builder       = LineAttributeBuilder::new(text,glyph_builder,self.max_displayed_chars);
+        self.texture_coords_data.extend(builder.flatten().map(|f| f as f32));
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::text::buffer::glyph_square::{GlyphAttributeBuilder,GlyphVertexPositionBuilder};
+
+    use basegl_core_msdf_sys::test_utils::TestAfterInit;
+    use nalgebra::Point2;
+    use std::future::Future;
+    use wasm_bindgen_test::wasm_bindgen_test;
+
+
+    #[wasm_bindgen_test(async)]
+    fn build_data_for_empty_line() -> impl Future<Output=()> {
+        TestAfterInit::schedule(|| {
+            let mut font = FontRenderInfo::mock_font("Test font".to_string());
+
+            let mut builder = FragmentsDataBuilder {
+                vertex_position_data : Vec::new(),
+                texture_coords_data  : Vec::new(),
+                font                 : &mut font,
+                line_clip            : 10.0..80.0,
+                max_displayed_chars  : 100
+            };
+
+            let result = builder.build_for_line(0, "");
+
+            let expected_data = vec![0.0; 12 * 100];
+            assert!(result.is_none());
+            assert_eq!(expected_data, builder.vertex_position_data);
+            assert_eq!(expected_data, builder.texture_coords_data);
+        })
+    }
+
+    #[wasm_bindgen_test(async)]
+    fn build_data_various_lines() -> impl Future<Output=()> {
+        TestAfterInit::schedule(|| {
+            let mut font       = FontRenderInfo::mock_font("Test font".to_string());
+            let mut a_info     = font.mock_char_info('A');
+            a_info.advance     = 1.0;
+            let mut b_info     = font.mock_char_info('B');
+            b_info.advance     = 1.5;
+            font.mock_kerning_info('A', 'A', 0.0);
+            font.mock_kerning_info('B', 'B', 0.0);
+            font.mock_kerning_info('A', 'B', 0.0);
+            font.mock_kerning_info('B', 'A', 0.0);
+            let shortest_line  = "AB";
+            let short_line     = "ABBA";
+            let medium_line    = "ABBAAB";
+            let long_line      = "ABBAABBABBA";
+
+            let mut builder = FragmentsDataBuilder {
+                vertex_position_data : Vec::new(),
+                texture_coords_data  : Vec::new(),
+                font                 : &mut font,
+                line_clip            : 5.5..8.0,
+                max_displayed_chars  : 3
+            };
+            let shortest_result = builder.build_for_line(1,shortest_line).unwrap();
+            let short_result    = builder.build_for_line(2,short_line).unwrap();
+            let medium_result   = builder.build_for_line(3,medium_line).unwrap();
+            let long_result     = builder.build_for_line(4,long_line).unwrap();
+
+            assert_eq!(0, shortest_result.first_char.byte_offset);
+            assert_eq!(1, shortest_result.last_char .byte_offset);
+            assert_eq!(1, short_result   .first_char.byte_offset);
+            assert_eq!(3, short_result   .last_char .byte_offset);
+            assert_eq!(3, medium_result  .first_char.byte_offset);
+            assert_eq!(5, medium_result  .last_char .byte_offset);
+            assert_eq!(4, long_result    .first_char.byte_offset);
+            assert_eq!(6, long_result    .last_char .byte_offset);
+
+            assert_eq!(Point2::new(0.0, -2.0), shortest_result.first_char.pen.position);
+            assert_eq!(Point2::new(1.0, -2.0), shortest_result.last_char .pen.position);
+            assert_eq!(Point2::new(1.0, -3.0), short_result   .first_char.pen.position);
+            assert_eq!(Point2::new(4.0, -3.0), short_result   .last_char .pen.position);
+            assert_eq!(Point2::new(4.0, -4.0), medium_result  .first_char.pen.position);
+            assert_eq!(Point2::new(6.0, -4.0), medium_result  .last_char .pen.position);
+            assert_eq!(Point2::new(5.0, -5.0), long_result    .first_char.pen.position);
+            assert_eq!(Point2::new(7.5, -5.0), long_result    .last_char .pen.position);
+
+            let vertex_glyph_data_size    = GlyphVertexPositionBuilder::OUTPUT_SIZE;
+            let tex_coord_glyph_data_size = GlyphTextureCoordsBuilder::OUTPUT_SIZE;
+            let glyphs_count              = builder.max_displayed_chars * 4;
+            let vertex_data_size          = vertex_glyph_data_size * glyphs_count;
+            let tex_coord_data_size       = tex_coord_glyph_data_size * glyphs_count;
+            assert_eq!(vertex_data_size   , builder.vertex_position_data.len());
+            assert_eq!([0.0, -2.0], builder.vertex_position_data[0..2]);
+            assert_eq!(tex_coord_data_size, builder.texture_coords_data.len());
+        })
+    }
+
+    #[wasm_bindgen_test(async)]
+    fn build_data_with_non_ascii() -> impl Future<Output=()> {
+        TestAfterInit::schedule(|| {
+            let mut font   = FontRenderInfo::mock_font("Test font".to_string());
+            let mut a_info = font.mock_char_info('Ą');
+            a_info.advance = 1.0;
+            let mut b_info = font.mock_char_info('B');
+            b_info.advance = 1.5;
+            font.mock_kerning_info('Ą', 'B', 0.0);
+            let line       = "ĄB";
+
+            let mut builder = FragmentsDataBuilder {
+                vertex_position_data : Vec::new(),
+                texture_coords_data  : Vec::new(),
+                font                 : &mut font,
+                line_clip            : 0.0..10.0,
+                max_displayed_chars  : 3
+            };
+            let result = builder.build_for_line(1,line).unwrap();
+
+            assert_eq!(0, result.first_char.byte_offset);
+            assert_eq!(2, result.last_char.byte_offset);
+        })
+    }
+}

--- a/lib/core/src/text/msdf_frag.glsl
+++ b/lib/core/src/text/msdf_frag.glsl
@@ -1,6 +1,7 @@
 #extension GL_OES_standard_derivatives : enable
 
 varying highp vec2 vTexCoord;
+varying highp vec4 vClipDistance;
 
 uniform sampler2D   msdf;
 // Number of MSDF cells in row and column
@@ -15,18 +16,22 @@ highp float median(highp vec3 v) {
 }
 
 void main() {
+    bool clipped              = any(lessThan(vClipDistance, vec4(0.0)));
     highp vec2  msdfUnitTex   = range/msdfSize;
     highp vec2  msdfUnitPx    = msdfUnitTex/fwidth(vTexCoord);
     highp float avgMsdfUnitPx = (msdfUnitPx.x + msdfUnitPx.y) / 2.0;
     // Note [dpiDilate]
     highp float dpiDilate     = avgMsdfUnitPx < range*0.49 ? 1.0 : 0.0;
 
-    highp vec3  msdfSample    = texture2D(msdf, vTexCoord).rgb;
-    highp float sigDist       = median(msdfSample) - 0.5;
-
-    highp float sigDistPx     = sigDist * avgMsdfUnitPx;
-    highp float opacity       = 0.5 + sigDistPx + dpiDilate*0.1;
-    gl_FragColor = vec4(color.xyz, color.w * clamp(opacity, 0.0, 1.0));
+    if (clipped) {
+        discard;
+    } else {
+        highp vec3  msdfSample    = texture2D(msdf, vTexCoord).rgb;
+        highp float sigDist       = median(msdfSample) - 0.5;
+        highp float sigDistPx     = sigDist * avgMsdfUnitPx;
+        highp float opacity       = 0.5 + sigDistPx + dpiDilate*0.1;
+        gl_FragColor = vec4(color.xyz, color.w * clamp(opacity, 0.0, 1.0));
+    }
 }
 
 /* Note [dpiDilate]

--- a/lib/core/src/text/msdf_vert.glsl
+++ b/lib/core/src/text/msdf_vert.glsl
@@ -1,9 +1,20 @@
 attribute vec2 position;
 attribute vec2 texCoord;
 
+uniform highp mat3 toWindow;
+uniform highp vec2 clipLower;
+uniform highp vec2 clipUpper;
+
 varying vec2 vTexCoord;
+varying vec4 vClipDistance;
 
 void main() {
+    highp vec3 positionOnWindow = toWindow * vec3(position, 1.0);
+    vClipDistance.x = positionOnWindow.x - clipLower.x;
+    vClipDistance.y = positionOnWindow.y - clipLower.y;
+    vClipDistance.z = clipUpper.x - positionOnWindow.x;
+    vClipDistance.w = clipUpper.y - positionOnWindow.y;
+
     vTexCoord = texCoord;
     gl_Position = vec4(position, 0.0, 1.0);
 }

--- a/lib/core/src/text/msdf_vert.glsl
+++ b/lib/core/src/text/msdf_vert.glsl
@@ -16,5 +16,5 @@ void main() {
     vClipDistance.w = clipUpper.y - positionOnWindow.y;
 
     vTexCoord = texCoord;
-    gl_Position = vec4(position, 0.0, 1.0);
+    gl_Position = vec4(positionOnWindow.xy, 0.0, positionOnWindow.z);
 }


### PR DESCRIPTION
### Pull Request Description
Text in text component is clipped to specified area on screen. Only visible part of text have its data in opengl buffers. The buffer management was somewhat adapted to quick scrolling with minimum buffer data refreshing.

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/luna/enso/blob/master/doc/rust-style-guide.md), [Scala](https://github.com/luna/enso/blob/master/doc/scala-style-guide.md), [Java](https://github.com/luna/enso/blob/master/doc/java-style-guide.md) or [Haskell](https://github.com/luna/enso/blob/master/doc/haskell-style-guide.md) style guides as appropriate.
- [x] All code has been tested where possible.

