### PR TITLE
Using Firefox for headless web tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,6 +42,8 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
+      - name: Install Firefox
+        run: sudo apt-get install firefox
       - name: Run wasm-pack tests
         uses: actions-rs/cargo@v1
         with:
@@ -49,7 +51,7 @@ jobs:
           args: >
             --manifest-path=script/rust/Cargo.toml
             --bin test-all
-            -- --node --firefox --headless
+            -- --headless --firefox
 
 # TODO[AO] formatter does not work
 #  fmt:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,8 +42,8 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-      - name: Install Firefox
-        run: sudo apt-get install firefox
+#      - name: Install Firefox
+#        run: sudo apt-get install firefox
       - name: Run wasm-pack tests
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,9 +33,6 @@ jobs:
         with:
           toolchain: nightly-2019-11-04
           override: true
-      - uses: nanasess/setup-chromedriver@master
-        with:
-          chromedriver-version: '78.0.3904.105'
       - name: Install wasm-pack
         uses: actions-rs/cargo@v1
         with:
@@ -52,7 +49,7 @@ jobs:
           args: >
             --manifest-path=script/rust/Cargo.toml
             --bin test-all
-            -- --node --chrome --headless
+            -- --node --firefox --headless
 
 # TODO[AO] formatter does not work
 #  fmt:

--- a/script/test.sh
+++ b/script/test.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 cargo test &&
-cargo run --manifest-path=script/rust/Cargo.toml --bin test-all -- \
-   --node --firefox --chrome --headless
+cargo run --manifest-path=script/rust/Cargo.toml --bin test-all -- --headless --firefox


### PR DESCRIPTION
### Pull Request Description
Running web tests in Chrome sometimes gets stuck with a message `Loading scripts...`. This PR switches the browser of choice for our web tests from Chrome to Firefox.

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/luna/enso/blob/master/doc/rust-style-guide.md), [Scala](https://github.com/luna/enso/blob/master/doc/scala-style-guide.md), [Java](https://github.com/luna/enso/blob/master/doc/java-style-guide.md) or [Haskell](https://github.com/luna/enso/blob/master/doc/haskell-style-guide.md) style guides as appropriate.
- [x] All code has been tested where possible.

